### PR TITLE
Support GIFs in hat commands

### DIFF
--- a/cogs/image.py
+++ b/cogs/image.py
@@ -42,6 +42,11 @@ class image(commands.Cog):
                 image = str(ctx.author.display_avatar)
 
         img_outname = image.split('/')[-1].split('?')[0].split('#')[0] # this is kind of dumb tbqh
+        root, ext = os.path.splitext(img_outname)
+        if ext.lower() == ".gif":
+            # hatten() uses cv2.imwrite, which doesn't support writing GIFs. Pillow does,
+            # but we might as well use PNG since it isn't limited to 256 colors.
+            img_outname = root + ".png"
         img_outname = self.reserve_imgname(img_outname)
 
         async with ctx.typing():
@@ -79,6 +84,11 @@ class image(commands.Cog):
                 image = str(ctx.author.display_avatar)
 
         img_outname = image.split('/')[-1].split('?')[0].split('#')[0] # this is kind of dumb tbqh
+        root, ext = os.path.splitext(img_outname)
+        if ext.lower() == ".gif":
+            # hatten() uses cv2.imwrite, which doesn't support writing GIFs. Pillow does,
+            # but we might as well use PNG since it isn't limited to 256 colors.
+            img_outname = root + ".png"
         img_outname = self.reserve_imgname(img_outname)
 
         async with ctx.typing():


### PR DESCRIPTION
When `!santahat` or `!heard` is run on a GIF, `lib.hat.hatten()` tries to save the output as a GIF. This is because the input filename (and extension) are reused for the output.

But, `lib.hat.hatten()` uses `cv2.imwrite()`, which does not support saving GIFs. Pillow does support saving GIFs, but it seems better to use PNG, as it doesn't have a limit of 256 colors.

Note that only the first frame of the GIF will be enhattened. If desired, [`Image.seek()`](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.seek) could be used to get each frame for enhattening.